### PR TITLE
Add `--text-file` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ For sending a simple text message to a user o group, run:
     $ tgm message send --text 'Hello' --chat-id 123456
     message-id: 676
 
+### Text from a stream (file or stdin)
+
+For sending the content of a text file as message text:
+
+    # you have a text file with a message you want to send
+    echo "hey dude" > message.txt 
+
+    # (1) use the `--text-file` option
+    tgm message send --chat-id 123456 --text-file message.txt 
+
+    # (2) use `<`
+    tgm message send --chat-id 123456 < message.txt 
+
+    # (3) use `|`
+    cat message.txt | tgm message send --chat-id 123456
+    # or
+    echo "hey dude, it's me again" | tgm message send --chat-id 123456 
+
+    # (4) type your message and send it by typing `CTRL+D`
+    tgm message send --chat-id 123456
+    Hey dude, yeah it's me again!
+    <CTRL+D>
+
 ### Parse modes
 
 For using one of the supported parse modes (`MarkdownV2` or `HTML`) of the entities in the message, run:

--- a/telegram_cli/telegram.py
+++ b/telegram_cli/telegram.py
@@ -12,7 +12,7 @@ class Client:
         self.verbose = verbose
 
     @staticmethod
-    def from_envorinment(verbose: bool = False) -> "Client":
+    def from_environment(verbose: bool = False) -> "Client":
         """Create a client from the TELEGRAM_TOKEN environment variable."""
 
         if "TELEGRAM_TOKEN" not in os.environ:

--- a/tests/cassettes/test_message_send/test_send_from_a_file.yaml
+++ b/tests/cassettes/test_message_send/test_send_from_a_file.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://api.telegram.org/1234567890abcdef1234567890abcdef/sendMessage?chat_id=123456&text=Hello%2C+world%21
+  response:
+    body:
+      string: '{"ok":false,"error_code":404,"description":"Not Found"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Type,Date,Server,Connection
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 18 Feb 2023 07:07:33 GMT
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/cassettes/test_message_send_from_stream/test_send_from_a_file.yaml
+++ b/tests/cassettes/test_message_send_from_stream/test_send_from_a_file.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://api.telegram.org/1234567890abcdef1234567890abcdef/sendMessage?chat_id=123456&text=Hello%2C+world%21
+  response:
+    body:
+      string: '{"ok":true,"result":{"message_id":734,"from":{"id":1051994739,"is_bot":true,"first_name":"Hogwarts
+        Bot","username":"hogwarts_api_bot"},"chat":{"id":123456,"first_name":"Maurizio","last_name":"Branca","username":"zmoog","type":"private"},"date":1676708914,"text":"Hello,
+        world!"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Type,Date,Server,Connection
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 18 Feb 2023 08:28:34 GMT
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_message_send_from_stream/test_send_reading_to_stdin.yaml
+++ b/tests/cassettes/test_message_send_from_stream/test_send_reading_to_stdin.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://api.telegram.org/1234567890abcdef1234567890abcdef/sendMessage?chat_id=123456&text=Hello%2C+world%21
+  response:
+    body:
+      string: '{"ok":true,"result":{"message_id":733,"from":{"id":1051994739,"is_bot":true,"first_name":"Hogwarts
+        Bot","username":"hogwarts_api_bot"},"chat":{"id":123456,"first_name":"Maurizio","last_name":"Branca","username":"zmoog","type":"private"},"date":1676708679,"text":"Hello,
+        world!"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Type,Date,Server,Connection
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 18 Feb 2023 08:24:39 GMT
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_message_send_from_stream.py
+++ b/tests/test_message_send_from_stream.py
@@ -1,0 +1,59 @@
+import io
+
+import pytest
+
+from click.testing import CliRunner
+from telegram_cli.cli import cli
+
+
+env = {
+    "TELEGRAM_TOKEN": "1234567890abcdef1234567890abcdef", # fake token for testing
+}
+
+
+@pytest.mark.vcr
+@pytest.mark.block_network
+def test_send_from_a_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+
+        # pick a message to send
+        message_text = "Hello, world!"
+
+        # Create a file with some text
+        with open("message.txt", "w") as f:
+            f.write("Hello, world!")
+        
+        # Send the message
+        result = runner.invoke(
+            cli,
+            ["-v", "message", "send", "--chat-id", "123456", "--text-file", "message.txt"],
+            env=env,
+        )
+
+        # Check the result
+        assert result.exit_code == 0
+        assert message_text in result.output
+
+
+@pytest.mark.vcr
+@pytest.mark.block_network
+def test_send_reading_to_stdin():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+
+        # pick a message to send
+        message_text = "Hello, world!"
+
+        # Send the message
+        result = runner.invoke(
+            cli,
+            ["-v", "message", "send", "--chat-id", "123456"],
+            env=env,
+            input=message_text,
+        )
+
+        # Check the result
+        assert not result.exception
+        assert result.exit_code == 0
+        assert message_text in result.output


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

We want to load the message text from the file, for example:

    tgm message send --chat-id 123456 --text-file message.txt

Optionally, user can use the path "-" to load the message from the std instead.

For example:

    # use `<`
    tgm message send --chat-id 123456 < message.txt

    # or use `|`
    cat message.txt | tgm message send --chat-id 123456
    # or
    echo "hey dude, it's me again" | tgm message send --chat-id 123456

    # or type your message and send it by typing `CTRL+D`
    tgm message send --chat-id 123456
    Hey dude, yeah it's me again!
    <CTRL+D>


### Change description
<!-- What does your code do? -->

Load the text message from a stream. The stream can be a file or the stdin.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Close zmoog/public-notes#4


### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.