### PR TITLE
Add send-document command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For sending the content of a text file as message text:
     Hey dude, yeah it's me again!
     <CTRL+D>
 
-### Parse modes
+#### Parse modes
 
 For using one of the supported parse modes (`MarkdownV2` or `HTML`) of the entities in the message, run:
 
@@ -64,6 +64,17 @@ For help, run:
 You can also use:
 
     python -m telegram_cli --help
+
+### Send a file document
+
+You can also send file documents:
+
+    # use the `--file` option for any kind of file.
+    tgm message send-document --chat-id 123456 --file report.pdf   
+
+    # use the `--caption` option to add a caption to your document.
+    tgm message send-document --chat-id 123456 --file report.pdf --caption "Here is the last report."
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -80,3 +80,16 @@ Now install the dependencies and test dependencies:
 To run the tests:
 
     pytest
+
+### Add new tests with Telegram API calls
+
+The pytest-recording pytest plugin records all HTTP requests and responses as a "cassette" in the `tests/cassettes/` folder.
+
+When you add a new test, you must run `pytest` using the `--record-mode` option. Here's an example:
+
+    pytest --record-mode=once test_send_message_document.py
+
+The `--record-mode` has multiple values:
+
+- `once` writes the HTTP traffic in a cassette once if there isn't an existing cassette for the test. If a cassette already exists, it uses its content for the test without sending any network traffic.
+- `rewrite` executes and rewrites all HTTP requests, even when a cassette already exists.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "requests",
     ],
     extras_require={
-        "test": ["pytest", "pytest-recording"]
+        "test": ["pytest", "pytest-recording", "ruff"]
     },
     python_requires=">=3.7",
 )

--- a/telegram_cli/cli.py
+++ b/telegram_cli/cli.py
@@ -1,5 +1,5 @@
 import sys
-from typing import TextIO
+from typing import TextIO, Union
 
 import click
 
@@ -46,7 +46,7 @@ def message(ctx: click.Context):
     default=None,
 )
 @click.pass_context
-def send(ctx: click.Context, text: str, text_file: TextIO, chat_id: str, parse_mode: str):
+def send(ctx: click.Context, text: str, text_file: Union[str, TextIO], chat_id: str, parse_mode: str):
     """Send a text message to a chat."""
     
     client = telegram.Client.from_environment(verbose=ctx.obj["verbose"])
@@ -60,6 +60,33 @@ def send(ctx: click.Context, text: str, text_file: TextIO, chat_id: str, parse_m
             message_text = f.read()
 
     resp = client.send(message_text, chat_id, parse_mode=parse_mode)
+
+    message_id = resp.get("result", {}).get("message_id", "No message id found")
+    click.echo(f"message-id: {message_id}")
+
+@message.command(name="send-document")
+@click.option(
+    "--file", 
+    help="Filename of the document to send.",
+    type=click.Path(file_okay=True, dir_okay=False, allow_dash=True),
+    default="-",
+)
+@click.option(
+    "--chat-id",
+    required=True,
+)
+@click.option(
+    "--caption",
+    help="Caption for the document to send.",
+    default=None,
+)
+@click.pass_context
+def send_document(ctx: click.Context, file: str, chat_id: str, caption: str = None):
+    """Send a document to a chat (with an optional caption)."""
+    
+    client = telegram.Client.from_environment(verbose=ctx.obj["verbose"])
+
+    resp = client.send_document(file, chat_id, caption)
 
     message_id = resp.get("result", {}).get("message_id", "No message id found")
     click.echo(f"message-id: {message_id}")

--- a/telegram_cli/telegram.py
+++ b/telegram_cli/telegram.py
@@ -47,3 +47,34 @@ class Client:
         r.raise_for_status()
         
         return r.json()
+
+
+    # https://core.telegram.org/api/files
+    def send_document(self, file_path: str, chat_id: str, caption: str = None) -> Dict[str, Any]:
+        """Send a file to a chat."""
+
+        params = {
+            'chat_id': chat_id,
+        }
+
+        if caption:
+            params['caption'] = caption
+
+        if self.verbose:
+            print(f"params: {params}")
+            print(f"Sending file to chat {chat_id}: {file_path}")
+
+        with open(file_path, 'rb') as f:
+            r = requests.post(
+                f'https://api.telegram.org/{self.token}/sendDocument',
+                params=params,
+                # files={'document': file_path}
+                files={'document': f}
+            )
+
+        if self.verbose:
+            print(r.text)
+
+        r.raise_for_status()
+
+        return r.json()

--- a/tests/cassettes/test_message_send_document/test_send_document_with_caption.yaml
+++ b/tests/cassettes/test_message_send_document/test_send_document_with_caption.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: "--29da7e91e2fde062cbf388e5304a8922\r\nContent-Disposition: form-data; name=\"document\";
+      filename=\"tmpsak4xv58\"\r\n\r\nThis is a test file.\r\n--29da7e91e2fde062cbf388e5304a8922--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '171'
+      Content-Type:
+      - multipart/form-data; boundary=29da7e91e2fde062cbf388e5304a8922
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://api.telegram.org/1234567890abcdef1234567890abcdef/sendDocument?chat_id=123456&caption=This+is+my+favourite+license
+  response:
+    body:
+      string: '{"ok":true,"result":{"message_id":2131,"from":{"id":1051994739,"is_bot":true,"first_name":"Hogwarts
+        Bot","username":"hogwarts_api_bot"},"chat":{"id":123456,"first_name":"Maurizio","last_name":"Branca","username":"zmoog","type":"private"},"date":1713683312,"document":{"file_name":"tmpsak4xv58","file_id":"BQACAgQAAxkDAAIIU2Yku3DBp1TLIi_Cj_lc-IbbbAOgAALPEgACnhkpUVjcD9bZI3aDNAQ","file_unique_id":"AgADzxIAAp4ZKVE","file_size":20},"caption":"This
+        is my favourite license"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Type,Date,Server,Connection
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '474'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 21 Apr 2024 07:08:32 GMT
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_message_send_document.py
+++ b/tests/test_message_send_document.py
@@ -1,0 +1,30 @@
+import tempfile
+
+import pytest
+
+from click.testing import CliRunner
+from telegram_cli.cli import cli
+
+
+env = {
+    "TELEGRAM_TOKEN": "1234567890abcdef1234567890abcdef", # fake token for testing
+}
+
+
+@pytest.mark.vcr
+@pytest.mark.block_network
+def test_send_document_with_caption(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with tempfile.NamedTemporaryFile(mode='w') as temp_file:
+            temp_file.write("This is a test file.")
+            temp_file.flush()
+            temp_file = temp_file.name
+
+            result = runner.invoke(
+                cli,
+                ["message", "send-document", "--file", temp_file, "--chat-id", "123456", "--caption", "This is my favourite license"],
+                env=env,
+            )
+            assert result.exit_code == 0
+            assert "message-id: 2131" in result.output

--- a/tests/test_message_send_from_stream.py
+++ b/tests/test_message_send_from_stream.py
@@ -1,4 +1,3 @@
-import io
 
 import pytest
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want to send PDF files to a group chat. 

### Change description
<!-- What does your code do? -->

Add a send a document with optional caption to a chat. Here's an example:

```shell
tgm message send-document --chat-id 123 --file 116602-1.pdf   
```

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.